### PR TITLE
Prefer Digest::SHA, fix quoting in fallback

### DIFF
--- a/lib/mini/Digest/SHA.pm
+++ b/lib/mini/Digest/SHA.pm
@@ -7,15 +7,22 @@ use strict;
 # The Digest::SHA module is in the perl-modules package, which is so large
 # that it would defeat the purpose of having a minimal system, so I cheat
 # by relying on the commandline tools in a hacky way
-#
-# TODO - try to load the Digest::SHA and use it if found
 
-#use Digest::SHA qw(sha256_hex);
+my $has_digest_sha = eval { require Digest::SHA; 1; };
 
-# Hack hack hackitty hack
 sub sha256 {
     my $input = shift;
-    my $rawoutput = `echo -n "$input" | sha256sum`;
+    if ($has_digest_sha) {
+        return Digest::SHA::sha256_hex($input);
+    } else {
+        return _sha256_shell($input);
+    }
+}
+
+# Hack hack hackitty hack
+sub _sha256_shell {
+    my $input = shift;
+    my $rawoutput = `/bin/echo -n \Q${input}\E | sha256sum`;
     return substr($rawoutput,0,64);
 }
 

--- a/lib/mini/Digest/SHA.t
+++ b/lib/mini/Digest/SHA.t
@@ -8,3 +8,8 @@ require_ok('mini::Digest::SHA');
 ## Test the sha256 hack
 is(mini::Digest::SHA::sha256(''),'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
 is(mini::Digest::SHA::sha256('test'),'9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08');
+
+is(mini::Digest::SHA::_sha256_shell('test' x 100),'8ccb865eb6b0788c55b354401531d133c35b93f9ab7d2670111437633307bf2f');
+is(mini::Digest::SHA::_sha256_shell('foo" #'), 'f6f3d444def883e897a15e0f9f3527978f985c5cd964fdd10e34e1702ea15f61');
+is(mini::Digest::SHA::_sha256_shell('-n foo" #'), '77da3100f771088f841e9c8c8c87c4fa10ec820bcf3797bb5d0e3afb6d682c75');
+is(mini::Digest::SHA::_sha256_shell('-n -c -x foo\\\\\ "\' " #'), '1d21804b2cc4db41f35cfdb19537701ba2a94c16c9cd570fd54742a5b2a9efcc'); 

--- a/lib/mini/Digest/SHA.t
+++ b/lib/mini/Digest/SHA.t
@@ -1,15 +1,24 @@
 # -*- perl -*-
 # Copyright (C) 2018 Hamish Coleman <hamish@zot.org>
 
-use Test::More 'no_plan';
+use Test::More;
 
 require_ok('mini::Digest::SHA');
 
 ## Test the sha256 hack
-is(mini::Digest::SHA::sha256(''),'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
-is(mini::Digest::SHA::sha256('test'),'9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08');
+my @sums = (
+     ['', 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'],
+     ['test', '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08'],
+     ['test' x 100, '8ccb865eb6b0788c55b354401531d133c35b93f9ab7d2670111437633307bf2f'],
+     ['foo" #', 'f6f3d444def883e897a15e0f9f3527978f985c5cd964fdd10e34e1702ea15f61'],
+     ['-n foo" #', '77da3100f771088f841e9c8c8c87c4fa10ec820bcf3797bb5d0e3afb6d682c75'],
+     ['-n -c -x foo\\\\\ "\' " #', '1d21804b2cc4db41f35cfdb19537701ba2a94c16c9cd570fd54742a5b2a9efcc']
+);
 
-is(mini::Digest::SHA::_sha256_shell('test' x 100),'8ccb865eb6b0788c55b354401531d133c35b93f9ab7d2670111437633307bf2f');
-is(mini::Digest::SHA::_sha256_shell('foo" #'), 'f6f3d444def883e897a15e0f9f3527978f985c5cd964fdd10e34e1702ea15f61');
-is(mini::Digest::SHA::_sha256_shell('-n foo" #'), '77da3100f771088f841e9c8c8c87c4fa10ec820bcf3797bb5d0e3afb6d682c75');
-is(mini::Digest::SHA::_sha256_shell('-n -c -x foo\\\\\ "\' " #'), '1d21804b2cc4db41f35cfdb19537701ba2a94c16c9cd570fd54742a5b2a9efcc'); 
+for (@sums) {
+    my ($in, $exp) = ($_->[0], $_->[1]);
+    is(mini::Digest::SHA::sha256($in), $exp, "sha256 of string $exp");
+    is(mini::Digest::SHA::_sha256_shell($in), $exp, "_sha256_shell of string $exp");
+}
+
+done_testing();


### PR DESCRIPTION
- Prefer Digest::SHA if it exists
- Using quotemeta to (attempt to) escape input to sha256sum
- Prefer gnu echo rather than the shell implementation for consistency

Would Digest::SHA::PurePerl, or IPC::Open2+sha256sum would be preferable to using backticks?