### PR TITLE
Run tests in minimal environment (request for comments)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM debian:9.5-slim
+COPY . /app
+WORKDIR /app
+RUN ./test_minimal

--- a/build_docker
+++ b/build_docker
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker build -tcjdns_tool .

--- a/cexec.t
+++ b/cexec.t
@@ -1,7 +1,8 @@
 # Copyright (C) 2018 Hamish Coleman <hamish@zot.org>
 
 # -*- perl -*-
-use Test::More 'no_plan';
+use mini::Test;
 
 require_ok('./cexec');
 
+done_testing();

--- a/lib/Bencode_bork.t
+++ b/lib/Bencode_bork.t
@@ -1,7 +1,7 @@
 # -*- perl -*-
 # Copyright (C) 2018 Hamish Coleman <hamish@zot.org>
 
-use Test::More 'no_plan';
+use mini::Test;
 
 require_ok('Bencode_bork');
 
@@ -30,6 +30,6 @@ is(Bencode_bork::encode($test_structure),$expect);
 # A string composed of a number is not detectable in the decoded structure
 # so, remove that from the expected structure - TODO, should it be detectable?
 $test_structure->{f} = '-200';
-
 is_deeply(Bencode_bork::decode($expect),$test_structure);
+done_testing()
 

--- a/lib/Cjdns/Addr.t
+++ b/lib/Cjdns/Addr.t
@@ -1,4 +1,4 @@
-use Test::More;
+use mini::Test;
 
 
 require_ok("Cjdns::Addr");

--- a/lib/Cjdns/RPC.t
+++ b/lib/Cjdns/RPC.t
@@ -1,7 +1,7 @@
 # -*- perl -*-
 # Copyright (C) 2018 Hamish Coleman <hamish@zot.org>
 
-use Test::More 'no_plan';
+use mini::Test;
 
 require_ok('Cjdns::RPC');
 
@@ -37,6 +37,8 @@ $expect = {
     },
 };
 is_deeply($rpc->_build_query_unauth('query', a1 => 'aa', a2 => 'bb'), $expect);
+
+done_testing();
 
 # TODO
 # - add tests for the authenticated packet builder

--- a/lib/Stream/String.t
+++ b/lib/Stream/String.t
@@ -1,7 +1,7 @@
 # -*- perl -*-
 # Copyright (C) 2018 Hamish Coleman <hamish@zot.org>
 
-use Test::More 'no_plan';
+use mini::Test;
 
 require_ok('Stream::String');
 
@@ -19,3 +19,4 @@ ok($sh->eof());
 is($sh->getc(),undef);
 ok($sh->ungetc());
 
+done_testing();

--- a/lib/mini/Data.t
+++ b/lib/mini/Data.t
@@ -1,7 +1,7 @@
 # -*- perl -*-
 # Copyright (C) 2018 Hamish Coleman <hamish@zot.org>
 
-use Test::More 'no_plan';
+use mini::Test;
 
 require_ok('mini::Data');
 
@@ -47,3 +47,4 @@ my $expect = <<'EOF';
 EOF
 is(mini::Data::Dumper($test_structure),$expect);
 
+done_testing();

--- a/lib/mini/Digest/SHA.t
+++ b/lib/mini/Digest/SHA.t
@@ -1,9 +1,7 @@
 # -*- perl -*-
 # Copyright (C) 2018 Hamish Coleman <hamish@zot.org>
 
-use Test::More;
-use Test::Exception;
-use MIME::Base64;
+use mini::Test;
 use v5.10;
 
 require_ok('mini::Digest::SHA');
@@ -30,9 +28,11 @@ my @sums = (
 
     [ pack('U*', (256..384)), sub {
           my ($fun, $in, $desc) = @_;
-          throws_ok { &$fun($in) } qr/Wide char/, qq[$desc throws on wide chars] }],
+          eval { &$fun($in) };
+          ok( scalar($@ =~ m/Wide char/), qq[$desc throws on wide chars]);
+      } ],
 
-    [ do { local undef $/; decode_base64(<DATA>)},
+    [ do { chomp(my $hex = <DATA>); pack("H*", $hex) }, 
       { sha256 => '239d4f4e08739eaccac0b99f050b6fd5502b7bc303fd7bdc42fc43ae59a79fd0',
         sha512 => '2d52a5f129a53ebbd05aeac31e257671a571ca7fc5dfd859c225d2416cb008494d40ebaeec0781d4bc25bda004dba111398892143c2092d511d8114f8ed3ef2d' }],
 );
@@ -62,10 +62,14 @@ sub test_sums {
 test_sums("sha256", "default code path", @sums);
 test_sums("sha512", "default code path", @sums);
 
-# Force Digest::SHA for completeness
-$mini::Digest::SHA::has_digest_sha = 1;
-test_sums("sha256", "explicit \$has_digest_sha", @sums);
-test_sums("sha512", "explicit \$has_digest_sha", @sums);
+
+my $has_digest_sha = eval {require Digest::SHA; 1};
+if ($has_digest_sha) {
+    # Force Digest::SHA for completeness
+    $mini::Digest::SHA::has_digest_sha = 1;
+    test_sums("sha256", "explicit \$has_digest_sha", @sums);
+    test_sums("sha512", "explicit \$has_digest_sha", @sums);
+}
 
 # Force the use of the sha256sum and IPC::Open2 implementation, thus testing the normal code path
 $mini::Digest::SHA::has_digest_sha = 0;
@@ -84,24 +88,4 @@ done_testing();
 
 
 __DATA__
-iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAABGdBTUEAALGPC/xhBQAAACBjSFJN
-AAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAA
-B3RJTUUH4goRDzA3WersswAAA+pJREFUSMfFVmtsFFUUbqAPUoNFDCQEjPGPxurOLlTolqqRGhKR
-gq2AhTYBJKYsAlGLVaCJ2GCaCr6Kok0VJZDyqAglaErTEkGrUAKS8tK0Bencee3s7M7uzM7O7s7L
-s61d2+1CZ6LFm5vde2/mnu+e8333nJuCxmP4eBv8jlFPAesDAP0DbHAQ74kr/VNs+PROn6WM3dn/
-9mDMQzTgy9gCmO3pdpT2X4QIT/ApzU7bi6VvW1XWqyA63PGbULePyS8lZxTgqVjCxqHxwO8AEB8z
-Ocsi5y9rvCB8uJfKXkjPXuZ5caPwaaNKsZpfjF7v9a2rRhmOkRtNkcyVVWqcn6/ciSY+QT5QIB1r
-E3cfYJ4so3OW4hl2lDWbXbw+eqU71HwKZeZYVhH7XLnm9buffZmetcRT8ka446LR3wI19bok+6t3
-h5rbfa/VEJPzwj9fEOr2W1MRkZWr9FHcys1MfpnG8cKufcZgi1y4Krf/Ymi61HRSV9XAjj3kQ/M1
-PkDbiiyoyFu+LdzZhbLmKDeRihilty8OYKiaWH8A/nUppOC0rii0vUhsaArs/Nq8imyh46f4ilrv
-miowBGTCSY0hLXTix6HTQE2Dp2hD5OK1pKFODhD944Z73mpxz3dGsha92mPo+j94LT9RjxVCJGMX
-xRRAKqbcIhlniXSkdahdfdAokKxrWnxFPt1JPbIApIwmOEZaSwYwzhbp+t09/xXxi4OGiSZ+fhDc
-Vbpv4ak2syRLTS0xDsrfGdW66uY8xRu9rmrpaBu6PQeJN9634T25tYOY9jTo73amIUrRKz3Ra73c
-ijf5tz4I7m02SzJ0cupTQBrjXMGVVhr94U5omhBU/iSUnr5A7Zfcyrf5iveDjd9bAICV8LlL7KK1
-fOUOue1s+FxX9PoNyD9xvWqiJLefDdQ24OOyudVbvGvflQ63WJDpIIDLt6kWEoYuRwY0E5ONroNM
-xYZD1KOF3jVbAYAtXOd7dTtcjngFNVUPxK+OBBtPoMlOvuoTYupc/7bP+M0fQXoAaXGrtjDO5bTt
-BTgBnoaR058Bb/xVddaSHWQhpbsP3Z/Hb/0Yn4B5XqqIqXBSLp7ugBxFZS+iHl+M7pkJY10Ow/GJ
-+/KslUwmt0S5SaCJOZ6lr8MxUeas4DdH4QLimTPZ5114hoN8sADqj0q62YUulGq9ZBKTnMCqb/12
-6uEFctuvKu2JdF4GPthCFzElP/TDGeBZ2LUfgC2UTHx4yWTmlgKfml8Q6w/TWDFULm75plgtC4bk
-kx3kjHkjNtoSSiY++rMFfE93DIthugPdO+ffFv2knya9LqNuvCsPr7vwdMTMhGjU/v+E6C+AW9i4
-DcGRTQAAAABJRU5ErkJggg==
+89504e470d0a1a0a0000000d4948445200000020000000200802000000fc18eda30000000467414d410000b18f0bfc6105000000206348524d00007a26000080840000fa00000080e8000075300000ea6000003a98000017709cba513c00000006624b474400ff00ff00ffa0bda7930000000774494d4507e20a110f303759eaecb3000003ea4944415448c7c5566b6c1455146ea00f5283450c24048cf18fc6eace2e54e896aa911a129182ad8085360124a62c02518b55a089d8609a0abe8aa24d152590f2a80825684ad31241ab500292f2d2b405e9dc79edececceeeccceceeececbb3ad5ddbed4267a2c59b9bdd7b6fe69eef9ef37df79c9b82c663f8781bfc8e514f01eb0300fd036c7010ef892bfd536cf8f44e9fa58cddd9fff660cc4334e0cbd80298ede97694f65f84084ff029cd4edb8ba56f5b55d6ab203adcf19b50b78fc92f256714e0a958c2c6a1f1c0ef00101f3339cb22e72f6bbc207cb897ca5e48cf5ee67971a3f069a34ab19a5f8c5eeff5adab46198e911b4d91cc95556a9c9fafdc89263e413e50201d6b13771f609e2ca37396e2197694359b5dbc3e7aa53bd47c0a65e6585611fb5cb9e6f5bb9f7d999eb5c453f246b8e3a2d1df0235f5ba24fbab77879adb7dafd51093f3c23f5f10eaf65b53119195abf451dccacd4c7e99c6f1c2ae7dc6608b5cb82ab7ff6268bad4745257d5c08e3de443f3353e40db8a2ca8c85bbe2ddcd985b2e62837918a18a5b72f0e60a89a587f00fe7529a4e0b4ae28b4bd486c680aecfcdabc8a6ca1e3a7f88a5aef9a2a300464c2498d212d74e2c7a1d3404d83a76843e4e2b5a4a14e0e10fde3867bde6a71cf7746b216bdda63e8fa3f782d3f518f1542246317c514402aa6dc2219678974a475a85d7dd02890ac6b5a7c453edd493db200a48c2638465a4b0630ce16e9fadd3dff15f18b838689267e7e10dc55ba6fe1a936b3244b4d2d310ecadf19d5baeae63cc51bbdae6ae9681bba3d078937deb7e13db9b58398f634e8ef76a6214ad12b3dd16bbddc8a37f9b73e08ee6d364b327472ea53401ae35cc195561afde14e689a1054fe24949ebe40ed97dccab7f98af7838ddf5b008095f0b94beca2b57ce50eb9ed6cf85c57f4fa0dc83f71bd6aa224b79f0dd436e0e3b2b9d55bbc6bdf950eb75890e92080cbb7a91612862e47063413938dae834cc58643d4a385de355b01802d5ce77b753b5c8e780535550fc4af8e041b4fa0c94ebeea1362ea5cffb6cff8cd1f417a006971abb630cee5b4ed0538019e8691d39f016ffc5575d6921d6421a5bb0fdd9fc76ffd189f80795eaa88a970522e9eee801c45652fa21e5f8cee9909635d0ec3f189fbf2ac954c26b744b949a089399ea5afc33151e6ace03747e102e29933d9e75d7886837cb000ea8f4abad9852e946abd6412939cc0aa6ffd76eae10572dbaf2aed89745e063ed8421731253ff4c319e059d8b51f802d944c7c78c964e696029f9a5f10eb0fd35831542e6ef9a6582d0b86e4931de48c792336da124a263efab3057c4f770c8b61ba03dd3be7df16fda49f26bd2ea36ebc2b0fafbbf074c4cc8468d4feff84e82f805bd8b80dc1914d0000000049454e44ae426082

--- a/lib/mini/Test.pm
+++ b/lib/mini/Test.pm
@@ -1,0 +1,199 @@
+package mini::Test;
+use strict;
+
+=head1 NAME
+
+mini::Test - Very small test module, base on Test::Tiny 
+
+=head1 SYNOPSIS
+
+    use Test::Tiny tests => NUMBER;
+    ok(TEST [, MESSAGE]);    # pass if TEST is true, and print MESSAGE
+    show(TEST);              # pass if eval(TEST) is true, print TEST
+    SKIP: {
+        skip(MESSAGE, N);
+        # skip this code, including N tests
+    }
+    BAIL_OUT([MESSAGE]);        # give up, printing MESSAGE.
+
+=cut
+
+our $VERSION = '0.02';
+our ($PLAN,$SUCC,$FAIL);
+sub import
+  {
+      no strict 'refs';
+    my $caller = caller;
+    *{"$caller\::$_"} = \&$_ for qw(ok show skip require_ok new_ok trows_ok is is_deeply BAIL_OUT done_testing);
+    $PLAN = @_ == 3 ? 0+$_[2] : -1;
+    if ($PLAN>0) {
+        print "1..", $PLAN < 0 ? 0 : $PLAN, "\n";
+    }
+    
+}
+
+sub ok
+{
+    my $res = shift;
+    if ($res) {
+        ++$SUCC;
+    } else {
+        print "not ";
+        ++$FAIL;
+    }
+    (my $desc = shift || '') =~ s/\n/\n# /g;
+    print "ok ", $SUCC + $FAIL, ($desc ? " - $desc" : ""), "\n";
+    if (!$res) {
+        my ($pack, $file, $line, $i);
+        ($pack, $file, $line) = caller(++$i) while $pack eq 'Test::Tiny';
+        print "# Failed at $file line $line\n";
+    }
+}
+
+sub is 
+{
+    my ($a, $b, $desc) = @_;
+    ok($a eq $b, $desc || "$a is $b");
+}
+
+sub require_ok {
+    my $req = shift;
+    my $pack = caller;
+    $req = "'$req'" if $req=~m/^\./;
+       my $code = <<REQUIRE;
+package $pack;
+require $req;
+1;
+REQUIRE
+
+eval $code;
+if ($@) {
+	ok(0, "require $req $@");
+} else {
+	ok(1, "require $req");
+}
+}
+
+sub new_ok {
+    my( $class, $args ) = @_;
+    my $obj;
+    eval {
+        $obj = $class->new(@$args);
+    };
+    if ($@ || !$obj) {
+        ok(0, "new $class $@");
+    } else {
+        ok(1, "new $class");
+    }
+    return $obj;
+}
+
+sub is_deeply {
+    my ($a, $b) = @_;
+    use mini::Data;
+    my $d = sub { mini::Data::Dumper(shift) };
+    ok(&$d($a) eq &$d($a), 'is_deeply');
+}
+
+sub show
+{
+    my $test = shift;
+    ok(eval($test), $test);
+}
+
+sub skip
+{
+    my ($why, $n) = @_;
+    ok(1, "skipped -- $why") while $n-- > 0;
+    last SKIP;
+}
+
+sub BAIL_OUT
+{
+    print "Bail out!", @_, "\n";
+    exit 255;
+}
+
+my $EXIT = sub {
+    exit($FAIL || abs($PLAN-$SUCC));
+};
+
+
+sub done_testing
+{
+    unless ($PLAN>0) {
+        $PLAN = $SUCC+$FAIL;
+    }
+    print "1..", $PLAN, "\n";
+    undef $EXIT;
+    exit $FAIL;
+}
+
+
+END { $EXIT->() if $EXIT; }
+
+1;
+__END__
+
+=head1 DESCRIPTION
+
+I I<thought> L<Test::Simple> was simple, but then I realized it relies
+on L<Test::Builder> to implement the one function it exports.
+Test::Tiny does more with less:
+
+=head3 C<ok(TEST [, MESSAGE])>
+
+Print C<"ok N - MESSAGE"> if C<TEST> is true, and C<"not ok N -
+MESSAGE"> otherwise.  The C<MESSAGE> is optional.
+
+=head3 C<show(EXPRESSION)>
+
+C<show> is like C<ok>, but uses C<eval(EXPRESSION)> as the C<TEST>,
+and uses C<EXPRESSION> as the C<MESSAGE>.  This is useful when your
+test is self-explanatory:
+
+    ok sqrt(4) == 2, 'sqrt(4) is 2'; # redundant
+    show 'sqrt(4) == 2';             # non-redundant
+
+=head3 C<skip(MESSAGE, NUMBER)>
+
+Skip C<NUMBER> tests with reason C<MESSAGE>:
+
+    SKIP: {
+        skip "message", $number;
+        # tests go here.
+    }
+
+=head3 C<BAIL_OUT(REASON)>
+
+Stop testing for C<REASON>.
+
+=head3 C<done_testing>
+
+Indicate that you finished running your tests.
+
+=head1 SEE ALSO
+
+L<Test::Simple>, L<Test::More>, L<Test::Builder>.
+
+=head1 AUTHOR
+
+Sean O'Rourke C<< <seano@cpan.org> >>.
+
+Bug reports welcome, patches even more welcome.
+
+Test::Tiny doesn't try to be 100% compatible with Test::Simple, but
+should stay clean, clear, and under 5% of Test::Simple's lines (from
+F<Simple.pm>, F<Builder.pm>, and files in F<@INC/Builder>).  Current
+counts are:
+
+    Test::Tiny    52   SLOC, 144  lines
+    Test::Simple  1345 SLOC, 3612 lines
+
+=head1 COPYRIGHT
+
+Copyright (C) 2010, 2011, Sean O'Rourke.
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut

--- a/test_minimal
+++ b/test_minimal
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+use strict;
+
+my @testfiles = map {chomp($_);$_} `find -name '*.t'`;
+
+my @failed;
+foreach my $t (@testfiles) {
+    print "\n$t\n".("-" x length($t))."\n";
+    my $failed = system("perl -Ilib $t");
+    if ($failed) {
+        push @failed, [$t, $failed];
+    }
+}
+
+if (@failed) {
+    die "\n======== FAIL! ==========\n"
+      . join("\n", map { $_->[0]." failed=".$_->[1]} @failed)
+      . "\n";
+} else {
+    print "\n[ OK ] No failures reported\n";
+    exit(0);
+}
+


### PR DESCRIPTION
- Add mini::Test that crudely implements Test::* features used
- Testing via docker's debian:9.5-slim image

PS: I don't actually think it's a good idea to merge this yet, mini::Test should perhaps fail over to Test::More if it exists, and there are probably bugs and other nasties.